### PR TITLE
Pgxn fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitignore export-ignore
+.gitattributes export-ignore
+.travis.yml export-ignore

--- a/META.json
+++ b/META.json
@@ -18,7 +18,7 @@
      }
   },
   "meta-spec": {
-     "version": "1.0.1",
+     "version": "1.0.0",
      "url": "http://pgxn.org/meta/spec.txt"
   },
   "tags": [

--- a/META.json
+++ b/META.json
@@ -32,5 +32,12 @@
       "docfile": "README.md",
       "version": "1.0.1"
     }
+  },
+  "prereqs": {
+    "runtime": {
+      "requires": {
+        "PostgreSQL": "9.1.0"
+      }
+    }
   }
 }


### PR DESCRIPTION
I think the issue with the v1.0.0 release to PGXN was that the `prefers` object in the `META.json` file was empty. PGXN should have complained about that, but my guess is that it checks for the existence of that object, not that it has contents. Dumb bug. Anyway, glad to see you added the section in a subsequent comment.

Meanwhile, I see that the release also had no README, no ChangeLog, almost nothing at all. I suggest merging this change, then you can make a new release like this:

     git archive --format zip --prefix=git_fdw-1.0.1/ --output git_fdw-1.0.1.zip

Then the upload of that zip file should index nicely. 