### PR TITLE
Fixed error: `too few arguments to function call, expected 5, have 4`

### DIFF
--- a/git_fdw.c
+++ b/git_fdw.c
@@ -308,7 +308,7 @@ static void gitBeginForeignScan(ForeignScanState *node, int eflags) {
       }
     }
 
-    error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL);
+    error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL, NULL);
     if (error < 0) {
       ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
             errmsg("Call to git_remote_connect failed"),


### PR DESCRIPTION
This pull request fixes the latest compiler error after adding support for bare repositories.