### PR TITLE
Wrap up scripts in Rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,10 @@ addons:
 services:
 - docker
 stages:
-  - build image and run tests
   - name: deploy
     if: tag =~ ^v
 jobs:
   include:
-    - stage: build image and run tests
-      script: ./scripts/build_image && ./scripts/run_tests
     - stage: deploy
       script: ./scripts/deploy
 env:

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+task :default do
+  system("./scripts/build_image && ./scripts/run_tests")
+  exit $?.exitstatus
+end


### PR DESCRIPTION
The base image is built on top of the Ruby worker, so to make it work
I'll just wrap up the scripts in a Rakefile for now.